### PR TITLE
Add support for passing single comma as parameter to local

### DIFF
--- a/lib/tokenize.js
+++ b/lib/tokenize.js
@@ -184,7 +184,7 @@ function depthSplit(text, delimiter, max){
     return []
   }
   
-  if (max === 1){
+  if (max === 1 || text.length === 1){
     return [text]
   }
   var remainder = text

--- a/test/query-tokenize.js
+++ b/test/query-tokenize.js
@@ -103,6 +103,11 @@ test('query parsing', function(t){
     ]}]}
   ])
 
+  check(".name:split(,)", [
+    {get: 'name'},
+    {filter: 'split', args: [',']}
+  ])
+
   check("items[id={.id}].name",[
     {root: true},
     {get: 'items'},


### PR DESCRIPTION
*EDIT: I reverted commits from PR https://github.com/mmckegg/json-query/pull/3 because I noticed my IDE and JSCS settings made unintended whitespace/code style changes to the files. Opening a new PR instead.*

I ran into an issue, where the json-query tokenizer was not able to parse passing a single `,` character as a local/global helper argument.

Neither could I find a way to escape the delimiter character.

In practice I wanted to import methods from `Array.prototype` `String.prototype` to queries, and these simple cases would fail:
```
".list:split(,)"  // "a,b" t=> ["a","b"]
".items.join(,)" // ["a","b"] => "a,b"
```

Unit test included. I am not very familiar with the tap framework, so please let me know if the test does not cover the case accurately enough, or if there is something wrong with the change in code, and I'll happily modify this.