### PR TITLE
add multiple return values + empty deep selector

### DIFF
--- a/index.js
+++ b/index.js
@@ -78,7 +78,13 @@ function handleToken(token, state){
       state.setCurrent(key, state.override[key])
     } else {
       if (state.currentItem || (state.options.force && state.force({}))){
-        state.setCurrent(key, state.currentItem[key])
+        if (state.currentItem instanceof Array && parseInt(key) != key){
+          state.setCurrent(key, state.currentItem.map(function(item){
+            return item[key]
+          }))
+        } else {
+          state.setCurrent(key, state.currentItem[key])
+        }
       } else {
         state.setCurrent(key, null)
       }
@@ -146,6 +152,9 @@ function handleToken(token, state){
     }
   } else if (token.deep){
     if (state.currentItem){
+      if (token.deep.length === 0){
+        return
+      }
       var result = state.deepQuery(state.currentItem, token.deep, state.options)
 
       if (result){

--- a/index.js
+++ b/index.js
@@ -79,9 +79,16 @@ function handleToken(token, state){
     } else {
       if (state.currentItem || (state.options.force && state.force({}))){
         if (state.currentItem instanceof Array && parseInt(key) != key){
-          state.setCurrent(key, state.currentItem.map(function(item){
-            return item[key]
-          }))
+          var result = []
+          state.currentItem.forEach(function(item){
+            var value = item[key]
+            if (value instanceof Array) {
+              result = result.concat(value)
+            } else {
+              result.push(value)
+            }
+          })
+          state.setCurrent(key, result)
         } else {
           state.setCurrent(key, state.currentItem[key])
         }


### PR DESCRIPTION
This allows multiple return values:

```js
var jsonQuery = require('json-query')
 
var data = {
  people: [
    {name: 'Matt', country: 'NZ'},
    {name: 'Pete', country: 'AU'}
  ]
}
 
jsonQuery('people.name', {
  data: data
}) //=> ['Matt', 'Pete'] 
```

and allows empty deep selectors:

```js
var jsonQuery = require('json-query')
 
var data = {
  people: [
    {name: 'Matt', country: 'NZ'},
    {name: 'Pete', country: 'AU'}
  ]
}
 
jsonQuery('people[]', {
  data: data
}) //=> [ {name: 'Matt', country: 'NZ'},  {name: 'Pete', country: 'AU'}]
```
