### PR TITLE
fix failing when filtering with RegExp on nonexisting key

### DIFF
--- a/index.js
+++ b/index.js
@@ -220,10 +220,10 @@ function matches (item, parts) {
       r = opts.func(item)
     } else if (opts.op === '~') {
       if (opts.value instanceof RegExp) {
-        r = !!item[opts.key].match(opts.value)
+        r = item[opts.key] && !!item[opts.key].match(opts.value)
       } else {
         console.log(opts.key, item)
-        r = !!~item[opts.key].indexOf(opts.value)
+        r = item[opts.key] && !!~item[opts.key].indexOf(opts.value)
       }
     } else if (opts.op === '=') {
       if ((item[opts.key] === true && opts.value === 'true') || (item[opts.key] === false && opts.value === 'false')) {

--- a/test/query.js
+++ b/test/query.js
@@ -174,6 +174,13 @@ test("RegExp filtering", function(t){
   t.end()
 })
 
+test("RegExp filtering - nonexisting key", function(t){
+  var result = jsonQuery('items[surname~/^T/].name', regExpOpts)
+
+  t.equal(result.value, null)
+  t.end()
+})
+
 test("RegExp filtering without allowRegexp throw error", function(t){
   t.throws(function () {
     jsonQuery('items[name~/^T/].name', { rootContext: rootContext })


### PR DESCRIPTION
At the moment, if you try to filter results using RegExp on nonexisting key, script completely fails, due to the fact that in `!!item[opts.key].match(opts.value)` `item[opts.key]` is `undefined` and therefore calling `match()` will make it fail. 

Check on existence of `item[opts.key]` fixes it easily.

I also added a test to cover this functionality.