### PR TITLE
Check for undefined instead of falsey value at the end of a query

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ function handleToken (token, state) {
 
   if (token == null) {
     // process end of query
-    if (!state.currentItem && state.options.force) {
+    if (typeof state.currentItem === "undefined" && state.options.force) {
       state.force(state.options.force)
     }
   } else if (token.values) {


### PR DESCRIPTION
See Issue #48
Fixed an issue where handleToken was checking for falsey value instead of undefined at the end of a query